### PR TITLE
Record Musicbrainz DiscID metadata using libdiscid.

### DIFF
--- a/src/cyanrip_encode.c
+++ b/src/cyanrip_encode.c
@@ -121,13 +121,14 @@ static void set_metadata(cyanrip_ctx *ctx, cyanrip_track *t, AVFormatContext *av
 
     strftime(t_disc_date, sizeof(t_disc_date), "%FT%H:%M:%S", ctx->disc_date);
 
-    av_dict_set    (&avf->metadata, "comment",       "cyanrip",         0);
-    av_dict_set    (&avf->metadata, "title",         t->name,           0);
-    av_dict_set_int(&avf->metadata, "track",         t->index + 1,      0);
-    av_dict_set    (&avf->metadata, "creation_time", t_s,               0);
-    av_dict_set    (&avf->metadata, "album",         ctx->disc_name,    0);
-    av_dict_set    (&avf->metadata, "album_artist",  ctx->album_artist, 0);
-    av_dict_set    (&avf->metadata, "date",          t_disc_date,       0);
+    av_dict_set    (&avf->metadata, "comment",            "cyanrip",         0);
+    av_dict_set    (&avf->metadata, "title",              t->name,           0);
+    av_dict_set_int(&avf->metadata, "track",              t->index + 1,      0);
+    av_dict_set    (&avf->metadata, "creation_time",      t_s,               0);
+    av_dict_set    (&avf->metadata, "album",              ctx->disc_name,    0);
+    av_dict_set    (&avf->metadata, "album_artist",       ctx->album_artist, 0);
+    av_dict_set    (&avf->metadata, "date",               t_disc_date,       0);
+    av_dict_set    (&avf->metadata, "musicbrainz_discid", ctx->discid,       0);
 }
 
 int cyanrip_encode_track(cyanrip_ctx *ctx, cyanrip_track *t,

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -147,6 +147,17 @@ void cyanrip_fill_metadata(cyanrip_ctx *ctx)
     /* Album time */
     time_t t_c = time(NULL);
     ctx->disc_date = localtime(&t_c);
+
+    /* DiscID */
+    DiscId *disc;
+    disc = discid_new();
+    if (discid_read_sparse(disc, ctx->settings.dev_path, 0) == 0) {
+        cyanrip_log(ctx, 0, "DiscID error: %s\n", discid_get_error_msg(disc));
+    } else {
+        strcpy(ctx->discid, discid_get_id(disc));
+    }
+    discid_free(disc);
+    cyanrip_log(ctx, 0, "DiscID: %s\n", ctx->discid);
 }
 
 void cyanrip_read_frame(cyanrip_ctx *ctx, cyanrip_track *t)

--- a/src/cyanrip_main.h
+++ b/src/cyanrip_main.h
@@ -30,6 +30,8 @@
 #include <cdio/paranoia.h>
 #include <cdio/mmc.h>
 
+#include <discid/discid.h>
+
 enum cyanrip_cover_image_formats {
     CYANRIP_COVER_IMAGE_JPG,
     CYANRIP_COVER_IMAGE_PNG,
@@ -87,6 +89,7 @@ typedef struct cyanrip_ctx {
     char disc_name[256];
     char *disc_mcn;
     struct tm *disc_date;
+    char discid[64];
     /* Metadata */
 
     void *cover_image_pkt; /* Cover image, init using cyanrip_setup_cover_image() */

--- a/wscript
+++ b/wscript
@@ -38,6 +38,7 @@ def configure(ctx):
     ctx.check_cfg(package='libavcodec', args='--cflags --libs', uselib_store='LAVC')
     ctx.check_cfg(package='libavformat', args='--cflags --libs', uselib_store='LAVF')
     ctx.check_cfg(package='libavutil', args='--cflags --libs', uselib_store='LAVU')
+    ctx.check_cfg(package='libdiscid', args='--cflags --libs', uselib_store='DISCID')
 
     if (VERSION):
         package_ver = VERSION
@@ -71,7 +72,7 @@ def build(ctx):
     )
     ctx(name='cyanrip',
         path=ctx.path,
-        uselib=['CDIO', 'PARA', 'LAVC', 'LAVF', 'LAVU'],
+        uselib=['CDIO', 'PARA', 'LAVC', 'LAVF', 'LAVU', 'DISCID'],
         use=['in_file', 'cyanrip_encode', 'cyanrip_log'],
         target=APPNAME,
         source='src/cyanrip_main.c',


### PR DESCRIPTION
If there's one thing cyanrip needs, it's more bloat.