### PR TITLE
cyanrip_log: Add os_compat.h for mkdir on win32

### DIFF
--- a/src/cyanrip_log.c
+++ b/src/cyanrip_log.c
@@ -24,6 +24,7 @@
 #include <libavutil/avutil.h>
 #include "cyanrip_encode.h"
 #include "cyanrip_log.h"
+#include "os_compat.h"
 
 /* Bump this on each change */
 #define LOG_VERSION 103


### PR DESCRIPTION
Fixes m-ab-s/media-autobuild_suite#1414