### PR TITLE
Add snap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,18 @@ build
 *.log
 .github/_build
 .github/_install
+
+# gitginore template for creating Snap packages
+# website: https://snapcraft.io/
+
+parts/
+prime/
+stage/
+*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2

--- a/README.md
+++ b/README.md
@@ -65,6 +65,33 @@ docker pull ep76/cyanrip
 
 If the latest build is broken, you can find older ones in the [nightly release page](https://github.com/cyanreg/cyanrip/releases/tag/nightly)
 
+### Snap Store
+
+cyanrip is available as a snap package on supported Linux distros. Install the snapd service following the [instructions](https://snapcraft.io/docs/installing-snapd).
+
+Install cyanrip:
+```bash
+snap install cyanrip
+```
+
+#### Building the snap (testing only)
+
+Currently only supported on amd64 Linux systems. Tested on Ubuntu 22.04 which is also the recommended build environment. Install snapcraft per the [instructions](https://snapcraft.io/docs/snapcraft-overview):
+```bash
+snap install snapcraft --classic
+lxd init --auto
+```
+
+From the root of the source code directory:
+```bash
+snapcraft
+```
+
+Resulting snap will **not** be signed and must be installed in devmode:
+```bash
+snap install cyanrip_<version>_amd64.snap --devmode
+```
+
 ### Compiling
 Complete list of dependencies:
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,97 @@
+name: cyanrip
+base: core22
+version: git
+summary: Fully featured CD ripping program able to take out most of the tedium
+license: LGPL-2.1-or-later
+description: |
+  Fully featured CD ripping program able to take out most of the tedium. Fully
+  accurate, has advanced features most rippers don't, yet has no bloat and is
+  cross-platform.
+
+contact: https://github.com/cyanreg/
+issues: https://github.com/cyanreg/cyanrip/issues
+source-code: https://github.com/cyanreg/cyanrip
+architectures:
+  # TODO: test other archs
+  - build-on: [amd64]
+    build-for: [amd64]
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+parts:
+  part-ffmpeg:
+    # Ubuntu 22.04 LTS bundles too old ffmpeg libraries, so build it here
+    # TODO: tests? https://ffmpeg.org/fate.html
+    plugin: autotools
+    source: https://git.ffmpeg.org/ffmpeg.git
+    source-branch: release/6.1
+    autotools-configure-parameters: [
+      # TODO: consider refactoring with build_ffmpeg() in mingw-build.sh
+      '--prefix="/usr"',
+      '--disable-autodetect',
+      '--disable-programs',
+      '--disable-doc',
+      '--disable-avdevice',
+      '--disable-swscale',
+      '--disable-postproc',
+      '--disable-network',
+      '--disable-bsfs',
+      '--disable-devices',
+      '--enable-shared',
+      '--enable-pthreads',
+      '--enable-bzlib',
+      '--enable-iconv',
+      '--enable-libfdk-aac',
+      '--enable-libmp3lame',
+      '--enable-libopus',
+      '--enable-libvorbis',
+      '--enable-lzma',
+      '--enable-zlib',
+    ]
+    build-packages:
+      - autoconf
+      - automake
+      - build-essential
+      - cmake
+      - git-core
+      - libbz2-dev
+      - libfdk-aac-dev
+      - libjconv-dev
+      - liblzma-dev
+      - libmp3lame-dev
+      - libopus-dev
+      - libtool
+      - libvorbis-dev
+      - yasm
+      - zlib1g-dev
+    stage-packages:
+      - libfdk-aac2
+      - libmp3lame0
+      - libopus0
+      - libvorbisenc2
+      
+  part-cyanrip:
+    after: [part-ffmpeg]
+    plugin: meson
+    meson-parameters: ['--prefix=/usr']
+    source: .
+    # TODO: override-pull can be used to parse `git describe` and set
+    #   grade/version accordingly (for tarball builds, etc.)
+    build-packages:
+      - gcc
+      - meson
+      - ninja-build
+      - libcdio-paranoia-dev
+      - libmusicbrainz5-dev
+      - libcurl4-openssl-dev
+    stage-packages:
+      - libcdio-paranoia2
+      - libcurl4
+      - libmusicbrainz5-2
+      
+apps:
+  cyanrip:
+    command: /usr/bin/cyanrip
+    plugs:
+      - network
+      - optical-drive


### PR DESCRIPTION
Although snaps are considered Ubuntu-centric, it's nice to have them available on other distros, for example I've been using this snap on Fedora for the last several months without issue.

Built on amd64 Ubuntu 23.04, tested on amd64 Fedora Workstation 38/39.

I didn't bother testing or implementing cross-compiling for i386, if that is desired then it's a lot more work IMO. Another option would be building on native i386.

I did notice that "cyanrip" is already registered on snapcraft.io, if that isn't owned or acquired by this project, then another name should be chosen e.g. cyanrip-snap.

Note: The snap can still be built and installed outside of the store using `--devmode`, if you elect not to use snapcraft.io. I mention that in the updated README.

Remaining steps:
- [ ] Set up project on snapcraft store
- [ ] Verify builds correctly on snapcraft.io
- [ ] Test build
- [ ] Adjust grade to stable in `snapcraft.yaml`