### PR TITLE
Add an option to specify the image size for cover lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Arguments are optional, except `-s`. By default cyanrip will rip all tracks from
 | -N                   | Disables MusicBrainz lookup and ignores lack of manual metadata to continue                 |
 | -A                   | Disables AccurateRip database query and comparison                                          |
 | -U                   | Disables Cover art DB database query and retrieval                                          |
+| -m                   | Lookup cover art with max size: 250, 500, 1200, -1 (no limit, default)                      |
 | -G                   | Disables embedding of cover art images                                                      |
 |                      | **Misc. options**                                                                           |
 | -Q                   | Eject CD tray if ripping has been successfully completed                                    |

--- a/src/coverart.c
+++ b/src/coverart.c
@@ -361,7 +361,8 @@ int crip_fill_coverart(cyanrip_ctx *ctx, int info_only)
         } else if (!ctx->settings.disable_coverart_db) {
             int has_err = 0;
             if (!have_front) {
-                has_err = fetch_image(ctx, curl_ctx, &ctx->cover_arts[ctx->nb_cover_arts], release_id, "front", info_only, NULL);
+                static const char *cover_ids[] = { "front", "front-250", "front-500", "front-1200" };
+                has_err = fetch_image(ctx, curl_ctx, &ctx->cover_arts[ctx->nb_cover_arts], release_id, cover_ids[ctx->settings.coverart_lookup_size], info_only, NULL);
                 if (has_err > 0) {
                     av_dict_set(&ctx->cover_arts[ctx->nb_cover_arts].meta, "title", "Front", 0);
                     av_dict_set(&ctx->cover_arts[ctx->nb_cover_arts].meta, "source", "Cover Art DB", 0);
@@ -370,7 +371,8 @@ int crip_fill_coverart(cyanrip_ctx *ctx, int info_only)
                 }
             }
             if (!have_back && (has_err > 0)) {
-                has_err = fetch_image(ctx, curl_ctx, &ctx->cover_arts[ctx->nb_cover_arts], release_id, "back", info_only, NULL);
+                static const char *cover_ids[] = { "back", "back-250", "back-500", "back-1200" };
+                has_err = fetch_image(ctx, curl_ctx, &ctx->cover_arts[ctx->nb_cover_arts], release_id, cover_ids[ctx->settings.coverart_lookup_size], info_only, NULL);
                 if (has_err > 0) {
                     av_dict_set(&ctx->cover_arts[ctx->nb_cover_arts].meta, "title", "Back", 0);
                     av_dict_set(&ctx->cover_arts[ctx->nb_cover_arts].meta, "source", "Cover Art DB", 0);

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -1415,6 +1415,7 @@ int main(int argc, char **argv)
     settings.print_info_only = 0;
     settings.disable_mb = 0;
     settings.disable_coverart_db = 0;
+    settings.coverart_lookup_size = COVERART_LOOKUP_SIZE_ORIGINAL;
     settings.decode_hdcd = 0;
     settings.deemphasis = 1;
     settings.force_deemphasis = 0;
@@ -1449,7 +1450,7 @@ int main(int argc, char **argv)
     int track_cover_arts_map[198] = { 0 };
     int nb_track_cover_arts = 0;
 
-    while ((c = getopt(argc, argv, "hNAUfHIVQEGWKOl:a:t:b:c:r:d:o:s:S:D:p:C:R:P:F:L:T:M:Z:")) != -1) {
+    while ((c = getopt(argc, argv, "hNAUfHIVQEGWKOl:a:t:b:c:r:d:o:s:S:D:p:C:R:P:F:L:T:M:Z:m:")) != -1) {
         switch (c) {
         case 'h':
             cyanrip_log(ctx, 0, "cyanrip %s (%s) help:\n", PROJECT_VERSION_STRING, vcstag);
@@ -1485,6 +1486,7 @@ int main(int argc, char **argv)
             cyanrip_log(ctx, 0, "    -N                    Disables MusicBrainz lookup and ignores lack of manual metadata\n");
             cyanrip_log(ctx, 0, "    -A                    Disables AccurateRip database query and validation\n");
             cyanrip_log(ctx, 0, "    -U                    Disables Cover art DB database query and retrieval\n");
+            cyanrip_log(ctx, 0, "    -m                    Lookup cover art with max size: 250, 500, 1200, -1 (no limit, default)\n");
             cyanrip_log(ctx, 0, "    -G                    Disables embedding of cover art images\n");
             cyanrip_log(ctx, 0, "\n  Misc. options:\n");
             cyanrip_log(ctx, 0, "    -Q                    Eject tray once successfully done\n");
@@ -1549,6 +1551,26 @@ int main(int argc, char **argv)
             break;
         case 'U':
             settings.disable_coverart_db = 1;
+            break;
+        case 'm':
+            long size = strtol(optarg, NULL, 10);
+            switch(size) {
+            case -1:
+                settings.coverart_lookup_size = COVERART_LOOKUP_SIZE_ORIGINAL;
+                break;
+            case 250:
+                settings.coverart_lookup_size = COVERART_LOOKUP_SIZE_250;
+                break;
+            case 500:
+                settings.coverart_lookup_size = COVERART_LOOKUP_SIZE_500;
+                break;
+            case 1200:
+                settings.coverart_lookup_size = COVERART_LOOKUP_SIZE_1200;
+                break;
+            default:
+                cyanrip_log(ctx, 0, "Invalid max coverart max size %i (must be 250, 500 or 1200)\n", size);
+                return 1;
+            }
             break;
         case 'b':
             settings.bitrate = strtof(optarg, NULL);

--- a/src/cyanrip_main.h
+++ b/src/cyanrip_main.h
@@ -83,6 +83,13 @@ enum CRIPSanitize {
     CRIP_SANITIZE_OS_UNICODE, /* Same as above, but only replaces symbols not allowed on current OS */
 };
 
+enum coverart_lookup_sizes {
+    COVERART_LOOKUP_SIZE_ORIGINAL = 0,
+    COVERART_LOOKUP_SIZE_250,
+    COVERART_LOOKUP_SIZE_500,
+    COVERART_LOOKUP_SIZE_1200
+};
+
 typedef struct cyanrip_settings {
     char *dev_path;
     char *folder_name_scheme;
@@ -110,6 +117,7 @@ typedef struct cyanrip_settings {
     int force_deemphasis;
     int ripping_retries;
     int disable_coverart_embedding;
+    enum coverart_lookup_sizes coverart_lookup_size;
     int enable_replaygain;
 
     enum cyanrip_output_formats outputs[CYANRIP_FORMATS_NB];


### PR DESCRIPTION
Some images of coverarchive.org are really huge. Personally I'm quite comfortable with smaller images. Thus I added an option to specify the desired size for cover lookup.

It would be nice, if you could merge that pull-request. If you aren't comfortable with the way I implemented that, feel free to ask me for modifications.

A great tool, btw. An easy to use CLI, a single C program with just a handful of dependencies. But it does all the daunting tasks to read out CDs and tag it nice for my music library. Thank you for that work!