### PR TITLE
[NOTFORMERGE] Crude attempt at ripping data track(s)

### DIFF
--- a/src/cue_writer.c
+++ b/src/cue_writer.c
@@ -112,8 +112,12 @@ void cyanrip_cue_track(cyanrip_ctx *ctx, cyanrip_track *t)
                 ctx->settings.outputs[Z] == CYANRIP_FORMAT_MP3 ? "MP3" :
                 t->track_is_data ? "BINARY" : "WAVE");
 
-        fprintf(ctx->cuefile[Z], "  TRACK %02d %s\n", t->number,
-                t->track_is_data ? "MODE1/2352" : "AUDIO");
+        const char *mode;
+        if (t->track_is_data)
+            mode = ctx->settings.data_as_iso ? "MODE1/2048" : "MODE1/2352";
+        else
+            mode = "AUDIO";
+        fprintf(ctx->cuefile[Z], "  TRACK %02d %s\n", t->number, mode);
 
         av_free(path);
     }

--- a/src/cyanrip_log.c
+++ b/src/cyanrip_log.c
@@ -316,7 +316,7 @@ void cyanrip_log_finish_report(cyanrip_ctx *ctx)
                     accurip_partial++;
             }
         }
-        cyanrip_log(ctx, 0, "Tracks ripped accurately: %i/%i\n", accurip_verified, ctx->nb_tracks);
+        cyanrip_log(ctx, 0, "Tracks ripped accurately: %i/%i\n", accurip_verified, ctx->nb_tracks - ctx->nb_data_tracks);
         if (accurip_partial)
             cyanrip_log(ctx, 0, "Tracks ripped partially accurately: %i/%i\n",
                         accurip_partial, ctx->nb_tracks - accurip_verified);

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -567,14 +567,16 @@ static int cyanrip_rip_data_track(cyanrip_ctx *ctx, cyanrip_track *t)
     }
 
     const int framesize = ctx->settings.data_as_iso ? CDIO_CD_FRAMESIZE : CDIO_CD_FRAMESIZE_RAW;
-    const int frames_per_read = 1;
-    const int bytes = frames_per_read * framesize;
-    buf = av_mallocz(bytes);
+    buf = av_mallocz(framesize * 2);
     if (!buf) {
         cyanrip_log(ctx, 0, "Unable to allocate memory\n");
         ret = AVERROR(ENOMEM);
         goto out;
     }
+
+    const int iso = ctx->settings.data_as_iso;
+    int offset_frames = iso ? 0 : (ctx->settings.offset << 2) / CDIO_CD_FRAMESIZE_RAW;
+    int offset_bytes = iso ? 0 : (ctx->settings.offset << 2) % CDIO_CD_FRAMESIZE_RAW;
 
 repeat_ripping:;
     cyanrip_checksum_ctx checksum_ctx;
@@ -587,19 +589,17 @@ repeat_ripping:;
         if (quit_now)
             return AVERROR(EINVAL);
 
-        const int frames_to_do = FFMIN(frames_per_read, t->frames - frames_done);
-        const int full = !ctx->settings.data_as_iso;
-        printf("Reading %d/%d ending %d\n", frames_done, t->frames, frames_done + frames_to_do);
-        driver_return_code_t drc = mmc_read_cd(ctx->cdio, buf, next_lsn,
-                                               0,  // any sector type
-                                               0,  // do not mask digital audio errors
-                                               full ? 1 : 0,  // return sync header
-                                               full ? 3 : 0,  // full sector header
-                                               1,  // return user data
-                                               full ? 1 : 0,  // return edc/ecc
-                                               0,  // do not return C2 correction info
-                                               0,  // do not return subchannel data
-                                               framesize, frames_to_do);
+        printf("Reading %d/%d\n", frames_done, t->frames);
+        driver_return_code_t drc = mmc_read_cd(ctx->cdio, buf, next_lsn + offset_frames,
+                                               iso ? 0 : 1,  // sector type (any / audio)
+                                               0,   // do not mask digital audio errors
+                                               0,   // do not return sync header
+                                               0,   // full sector header
+                                               1,   // return user data
+                                               0,   // return edc/ecc
+                                               0,   // do not return C2 correction info
+                                               0,   // do not return subchannel data
+                                               framesize, iso ? 1 : 2);
 
         if (drc == DRIVER_OP_SUCCESS) {
             tries = 0;
@@ -610,15 +610,30 @@ repeat_ripping:;
             if (tries < ctx->settings.max_retries)
                 continue;
             tries = 0;
-            memset(buf, 0, bytes);
+            memset(buf, 0, framesize*2);
         }
 
-        crip_process_checksums(&checksum_ctx, buf, bytes);
+        uint8_t *frameptr = buf + offset_bytes;
+
+        if (!iso) {
+            for (int i=0; i<CDIO_CD_SYNC_SIZE; i++) {
+                if (frameptr[i] != CDIO_SECTOR_SYNC_HEADER[i])
+                    printf("bad sync header\n");
+            }
+
+            uint16_t poly = 1;
+            for (int i=CDIO_CD_SYNC_SIZE; i<framesize; i++) {
+                frameptr[i] ^= poly;
+                poly = (((poly ^ (poly >> 1)) & 0xff) << 7) ^ (poly >> 8);
+            }
+        }
+
+        crip_process_checksums(&checksum_ctx, frameptr, framesize);
 
         for (int i = 0; i < ctx->settings.outputs_num; i++)
-            fwrite(buf, framesize, frames_to_do, binfps[i]);
-        frames_done += frames_to_do;
-        next_lsn += frames_to_do;
+            fwrite(frameptr, framesize, 1, binfps[i]);
+        frames_done += 1;
+        next_lsn += 1;
     }
 
     crip_finalize_checksums(&checksum_ctx, t);

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -199,6 +199,7 @@ static int cyanrip_ctx_init(cyanrip_ctx **s, cyanrip_settings *settings)
         return AVERROR(EINVAL);
     }
 
+    ctx->nb_data_tracks = 0;
     int first_track_nb = cdio_get_first_track_num(ctx->cdio);
     for (int i = 0; i < ctx->nb_cd_tracks; i++) {
         cyanrip_track *t = &ctx->tracks[i];
@@ -223,6 +224,7 @@ static int cyanrip_ctx_init(cyanrip_ctx **s, cyanrip_settings *settings)
         t->end_lsn_sig = t->end_lsn;
 
         if (t->track_is_data) {
+            ctx->nb_data_tracks += 1;
             if (ctx->settings.pregap_action[t->number - 1] == CYANRIP_PREGAP_DEFAULT)
                 ctx->settings.pregap_action[t->number - 1] = CYANRIP_PREGAP_DROP;
             if (ctx->settings.pregap_action[t->number - 0] == CYANRIP_PREGAP_DEFAULT)

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -575,8 +575,6 @@ static int cyanrip_rip_data_track(cyanrip_ctx *ctx, cyanrip_track *t)
     }
 
     const int iso = ctx->settings.data_as_iso;
-    int offset_frames = iso ? 0 : (ctx->settings.offset << 2) / CDIO_CD_FRAMESIZE_RAW;
-    int offset_bytes = iso ? 0 : (ctx->settings.offset << 2) % CDIO_CD_FRAMESIZE_RAW;
 
 repeat_ripping:;
     cyanrip_checksum_ctx checksum_ctx;
@@ -585,6 +583,9 @@ repeat_ripping:;
     int next_lsn = t->start_lsn;
     int frames_done = 0;
     int tries = 0;
+    int sync_found = 0;
+    int offset_frames = 0;
+    int offset_bytes = 0;
     while (frames_done < t->frames) {
         if (quit_now)
             return AVERROR(EINVAL);
@@ -613,18 +614,37 @@ repeat_ripping:;
             memset(buf, 0, framesize*2);
         }
 
-        uint8_t *frameptr = buf + offset_bytes;
+        uint8_t *frameptr;
 
-        if (!iso) {
-            for (int i=0; i<CDIO_CD_SYNC_SIZE; i++) {
-                if (frameptr[i] != CDIO_SECTOR_SYNC_HEADER[i])
-                    printf("bad sync header\n");
+        if (iso) {
+            frameptr = buf;
+        } else {
+            if (!sync_found) {
+                for (offset_bytes=0; offset_bytes<CDIO_CD_FRAMESIZE_RAW; offset_bytes++)
+                    if (!memcmp(&buf[offset_bytes], CDIO_SECTOR_SYNC_HEADER, CDIO_CD_SYNC_SIZE))
+                        break;
+                printf("Detected sync with %d byte offset\n", offset_bytes);
+                sync_found = 1;
+            }
+
+            frameptr = buf + offset_bytes;
+            if (memcmp(&buf[offset_bytes], CDIO_SECTOR_SYNC_HEADER, CDIO_CD_SYNC_SIZE)) {
+                printf("did not find sync header at lsn %d\n", next_lsn);
+                exit(1);    // needs strategy to handle
             }
 
             uint16_t poly = 1;
             for (int i=CDIO_CD_SYNC_SIZE; i<framesize; i++) {
                 frameptr[i] ^= poly;
                 poly = (((poly ^ (poly >> 1)) & 0xff) << 7) ^ (poly >> 8);
+            }
+
+            lsn_t lsn = cdio_msf_to_lsn((msf_t*)&frameptr[12]);
+
+            if (lsn != next_lsn) {
+                printf("Detected sync with %d frame offset\n", next_lsn - lsn);
+                offset_frames += next_lsn - lsn;
+                continue;
             }
         }
 

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -18,6 +18,7 @@
 
 #include <time.h>
 #include <getopt.h>
+#include <stdio.h>
 #include <sys/stat.h>
 
 #ifdef _WIN32
@@ -538,6 +539,139 @@ static void track_read_extra(cyanrip_ctx *ctx, cyanrip_track *t)
             }
         }
     }
+}
+
+static int cyanrip_rip_data_track(cyanrip_ctx *ctx, cyanrip_track *t)
+{
+    int ret = 0;
+    uint32_t total_repeats = 0;
+    uint32_t *last_checksums = NULL;
+    uint32_t nb_last_checksums = 0;
+
+    FILE *binfps[CYANRIP_FORMATS_NB] = {0};
+    uint8_t *buf = NULL;
+
+    for (int i = 0; i < ctx->settings.outputs_num; i++) {
+        const cyanrip_out_fmt *cfmt = &crip_fmt_info[ctx->settings.outputs[i]];
+        char *filename = crip_get_path(ctx, CRIP_PATH_TRACK, 1, cfmt, t);
+        binfps[i] = fopen(filename, "wb");
+        av_free(filename);
+
+        if (!binfps[i]) {
+            cyanrip_log(ctx, 0, "Unable to open output file %s\n", filename);
+            ret = AVERROR(EINVAL);
+            goto out;
+        }
+    }
+
+    const int framesize = ctx->settings.data_as_iso ? CDIO_CD_FRAMESIZE : CDIO_CD_FRAMESIZE_RAW;
+    const int frames_per_read = 1;
+    const int bytes = frames_per_read * framesize;
+    buf = av_mallocz(bytes);
+    if (!buf) {
+        cyanrip_log(ctx, 0, "Unable to allocate memory\n");
+        ret = AVERROR(ENOMEM);
+        goto out;
+    }
+
+repeat_ripping:;
+    cyanrip_checksum_ctx checksum_ctx;
+    crip_init_checksum_ctx(ctx, &checksum_ctx, t);
+
+    int next_lsn = t->start_lsn;
+    int frames_done = 0;
+    int tries = 0;
+    while (frames_done < t->frames) {
+        if (quit_now)
+            return AVERROR(EINVAL);
+
+        const int frames_to_do = FFMIN(frames_per_read, t->frames - frames_done);
+        const int full = !ctx->settings.data_as_iso;
+        printf("Reading %d/%d ending %d\n", frames_done, t->frames, frames_done + frames_to_do);
+        driver_return_code_t drc = mmc_read_cd(ctx->cdio, buf, next_lsn,
+                                               0,  // any sector type
+                                               0,  // do not mask digital audio errors
+                                               full ? 1 : 0,  // return sync header
+                                               full ? 3 : 0,  // full sector header
+                                               1,  // return user data
+                                               full ? 1 : 0,  // return edc/ecc
+                                               0,  // do not return C2 correction info
+                                               0,  // do not return subchannel data
+                                               framesize, frames_to_do);
+
+        if (drc == DRIVER_OP_SUCCESS) {
+            tries = 0;
+        } else {
+            const char *msg = cdio_driver_errmsg(drc);
+            cyanrip_log(ctx, 0, "Read error: %s\n", msg);
+            tries += 1;
+            if (tries < ctx->settings.max_retries)
+                continue;
+            tries = 0;
+            memset(buf, 0, bytes);
+        }
+
+        crip_process_checksums(&checksum_ctx, buf, bytes);
+
+        for (int i = 0; i < ctx->settings.outputs_num; i++)
+            fwrite(buf, framesize, frames_to_do, binfps[i]);
+        frames_done += frames_to_do;
+        next_lsn += frames_to_do;
+    }
+
+    crip_finalize_checksums(&checksum_ctx, t);
+    printf("crc: %x\n", checksum_ctx.eac_crc);
+
+    if (ctx->settings.ripping_retries) {
+        int matches = 0;
+        for (int i = 0; i < nb_last_checksums; i++)
+            matches += last_checksums[i] == checksum_ctx.eac_crc;
+
+        total_repeats++;
+        if (matches >= ctx->settings.ripping_retries) {
+            cyanrip_log(ctx, 0, "\nDone; (%i out of %i matches for current checksum %08X)\n",
+                        matches, ctx->settings.ripping_retries, checksum_ctx.eac_crc);
+            goto finalize_ripping;
+        }
+        if (total_repeats >= ctx->settings.max_retries) {
+            cyanrip_log(ctx, 0, "\nDone; (no matches found, but hit repeat limit of %i)\n",
+                        ctx->settings.max_retries);
+            goto finalize_ripping;
+        }
+
+        cyanrip_log(ctx, 0, "\nRepeating ripping (%i out of %i matches for current checksum %08X)\n",
+                    matches, ctx->settings.ripping_retries, checksum_ctx.eac_crc);
+
+        last_checksums = av_realloc(last_checksums,
+                                    (nb_last_checksums + 1)*sizeof(*last_checksums));
+        if (!last_checksums) {
+            ret = AVERROR(ENOMEM);
+            goto out;
+        }
+
+        last_checksums[nb_last_checksums] = checksum_ctx.eac_crc;
+        nb_last_checksums++;
+
+        for (int i = 0; i < ctx->settings.outputs_num; i++)
+            fseek(binfps[i], 0, SEEK_SET);
+
+        goto repeat_ripping;
+    }
+
+finalize_ripping:
+
+    cyanrip_log_track_end(ctx, t);
+    cyanrip_cue_track(ctx, t);
+
+out:
+    for (int i = 0; i < ctx->settings.outputs_num; i++)
+        if (binfps[i])
+            fclose(binfps[i]);
+
+    if (buf)
+        av_free(buf);
+
+    return ret;
 }
 
 static int cyanrip_rip_track(cyanrip_ctx *ctx, cyanrip_track *t)
@@ -1375,7 +1509,10 @@ char *crip_get_path(cyanrip_ctx *ctx, enum CRIPPathType type, int create_dirs,
         if (process_cond(ctx, &buf, t->meta, fmt->name, &dir_list, &dir_list_nb,
                          ctx->settings.track_name_scheme))
             goto end;
-        ext = av_strdup(t->track_is_data ? "bin" : fmt->ext);
+        if (t->track_is_data)
+            ext = av_strdup(ctx->settings.data_as_iso ? "iso" : "bin");
+        else
+            ext = av_strdup(fmt->ext);
     }
 
     if (ext)
@@ -1440,6 +1577,7 @@ int main(int argc, char **argv)
     settings.disable_coverart_embedding = 0;
     settings.enable_replaygain = 1;
     settings.paranoia_level = FF_ARRAY_ELEMS(paranoia_level_map) - 1;
+    settings.data_as_iso = 0;
 
     memset(settings.pregap_action, CYANRIP_PREGAP_DEFAULT, 198*sizeof(*settings.pregap_action));
 
@@ -1462,7 +1600,7 @@ int main(int argc, char **argv)
     int track_cover_arts_map[198] = { 0 };
     int nb_track_cover_arts = 0;
 
-    while ((c = getopt(argc, argv, "hNAUfHIVQEGWKOl:a:t:b:c:r:d:o:s:S:D:p:C:R:P:F:L:T:M:Z:m:")) != -1) {
+    while ((c = getopt(argc, argv, "hNAUfHIVQEGWKOil:a:t:b:c:r:d:o:s:S:D:p:C:R:P:F:L:T:M:Z:m:")) != -1) {
         switch (c) {
         case 'h':
             cyanrip_log(ctx, 0, "cyanrip %s (%s) help:\n", PROJECT_VERSION_STRING, vcstag);
@@ -1488,6 +1626,7 @@ int main(int argc, char **argv)
             cyanrip_log(ctx, 0, "    -M <string>           CUE file name scheme, by default its \"%s\"\n", settings.cue_name_scheme);
             cyanrip_log(ctx, 0, "    -l <list>             Select which tracks to rip (default: all)\n");
             cyanrip_log(ctx, 0, "    -T <string>           Filename sanitation: simple, os_simple, unicode (default), os_unicode\n");
+            cyanrip_log(ctx, 0, "    -i                    Rip data tracks as ISO files (default: .bin with mode1/2352 sectors)\n");
             cyanrip_log(ctx, 0, "\n  Metadata options:\n");
             cyanrip_log(ctx, 0, "    -I                    Only print CD and track info\n");
             cyanrip_log(ctx, 0, "    -a <string>           Album metadata, key=value:key=value\n");
@@ -1640,6 +1779,9 @@ int main(int argc, char **argv)
             break;
         case 'O':
             settings.overread_leadinout = 1;
+            break;
+        case 'i':
+            settings.data_as_iso = 1;
             break;
         case 'Z':
             settings.ripping_retries = strtol(optarg, NULL, 10);
@@ -1888,7 +2030,9 @@ int main(int argc, char **argv)
 
     /* Set default track title */
     for (int i = 0; i < ctx->nb_tracks; i++)
-        av_dict_set(&ctx->meta, "title", "Unknown track", 0);
+        av_dict_set(&ctx->meta, "title",
+                    ctx->tracks[i].track_is_data ? "Data track" : "Unknown track",
+                    0);
 
     /* Fill musicbrainz metadata */
     if (crip_fill_metadata(ctx,
@@ -2104,24 +2248,29 @@ int main(int argc, char **argv)
                     break;
                 }
             } else {
-                /* Initialize */
-                int ret = cyanrip_create_dec_ctx(ctx, &t->dec_ctx, t);
-                if (ret < 0) {
-                    cyanrip_log(ctx, 0, "Error initializing decoder: %s\n", av_err2str(ret));
-                    goto end;
-                }
-
-                for (int j = 0; j < ctx->settings.outputs_num; j++) {
-                    ret = cyanrip_init_track_encoding(ctx, &t->enc_ctx[j], t,
-                                                      ctx->settings.outputs[j]);
+                if (t->track_is_data) {
+                    if (cyanrip_rip_data_track(ctx, t))
+                        break;
+                } else {
+                    /* Initialize */
+                    int ret = cyanrip_create_dec_ctx(ctx, &t->dec_ctx, t);
                     if (ret < 0) {
-                        cyanrip_log(ctx, 0, "Error initializing encoder: %s\n", av_err2str(ret));
+                        cyanrip_log(ctx, 0, "Error initializing decoder: %s\n", av_err2str(ret));
                         goto end;
                     }
-                }
 
-                if (cyanrip_rip_track(ctx, t))
-                    break;
+                    for (int j = 0; j < ctx->settings.outputs_num; j++) {
+                        ret = cyanrip_init_track_encoding(ctx, &t->enc_ctx[j], t,
+                                                          ctx->settings.outputs[j]);
+                        if (ret < 0) {
+                            cyanrip_log(ctx, 0, "Error initializing encoder: %s\n", av_err2str(ret));
+                            goto end;
+                        }
+                    }
+
+                    if (cyanrip_rip_track(ctx, t))
+                        break;
+                }
             }
 
             if (quit_now)
@@ -2142,6 +2291,8 @@ int main(int argc, char **argv)
                 cyanrip_track *t = &ctx->tracks[i];
 
                 for (int j = 0; j < ctx->settings.outputs_num; j++) {
+                    if (t->track_is_data)
+                        continue;
                     int ret = cyanrip_writeout_track(ctx, t->enc_ctx[j]);
                     if (ret < 0) {
                         cyanrip_log(ctx, 0, "Error encoding: %s\n", av_err2str(ret));
@@ -2217,27 +2368,35 @@ int main(int argc, char **argv)
 
             cyanrip_track *t = &ctx->tracks[j];
 
-            /* Initialize */
-            int ret = cyanrip_create_dec_ctx(ctx, &t->dec_ctx, t);
-            if (ret < 0) {
-                cyanrip_log(ctx, 0, "Error initializing decoder: %s\n", av_err2str(ret));
-                goto end;
-            }
-
-            for (j = 0; j < ctx->settings.outputs_num; j++) {
-                ret = cyanrip_init_track_encoding(ctx, &t->enc_ctx[j], t,
-                                                  ctx->settings.outputs[j]);
+            if (t->track_is_data) {
+                int ret = cyanrip_rip_data_track(ctx, t);
                 if (ret < 0) {
-                    cyanrip_log(ctx, 0, "Error initializing encoder: %s\n", av_err2str(ret));
+                    cyanrip_log(ctx, 0, "Error ripping: %s\n", av_err2str(ret));
                     goto end;
                 }
-            }
+            } else {
+                /* Initialize */
+                int ret = cyanrip_create_dec_ctx(ctx, &t->dec_ctx, t);
+                if (ret < 0) {
+                    cyanrip_log(ctx, 0, "Error initializing decoder: %s\n", av_err2str(ret));
+                    goto end;
+                }
 
-            /* Rip */
-            ret = cyanrip_rip_track(ctx, t);
-            if (ret < 0) {
-                cyanrip_log(ctx, 0, "Error ripping: %s\n", av_err2str(ret));
-                goto end;
+                for (j = 0; j < ctx->settings.outputs_num; j++) {
+                    ret = cyanrip_init_track_encoding(ctx, &t->enc_ctx[j], t,
+                                                      ctx->settings.outputs[j]);
+                    if (ret < 0) {
+                        cyanrip_log(ctx, 0, "Error initializing encoder: %s\n", av_err2str(ret));
+                        goto end;
+                    }
+                }
+
+                /* Rip */
+                ret = cyanrip_rip_track(ctx, t);
+                if (ret < 0) {
+                    cyanrip_log(ctx, 0, "Error ripping: %s\n", av_err2str(ret));
+                    goto end;
+                }
             }
 
             if (quit_now)
@@ -2263,11 +2422,13 @@ int main(int argc, char **argv)
 
                 cyanrip_track *t = &ctx->tracks[j];
 
-                for (j = 0; j < ctx->settings.outputs_num; j++) {
-                    int ret = cyanrip_writeout_track(ctx, t->enc_ctx[j]);
-                    if (ret < 0) {
-                        cyanrip_log(ctx, 0, "Error encoding: %s\n", av_err2str(ret));
-                        goto end;
+                if (!t->track_is_data) {
+                    for (j = 0; j < ctx->settings.outputs_num; j++) {
+                        int ret = cyanrip_writeout_track(ctx, t->enc_ctx[j]);
+                        if (ret < 0) {
+                            cyanrip_log(ctx, 0, "Error encoding: %s\n", av_err2str(ret));
+                            goto end;
+                        }
                     }
                 }
 

--- a/src/cyanrip_main.h
+++ b/src/cyanrip_main.h
@@ -215,6 +215,7 @@ typedef struct cyanrip_ctx {
 
     cyanrip_track tracks[198];
     int nb_tracks; /* Total number of output tracks */
+    int nb_data_tracks; /* Total number of output tracks which are data, not audio */
     int nb_cd_tracks; /* Total tracks the CD signals */
     int disregard_cd_isrc; /* If one track doesn't have ISRC, universally the rest won't */
 

--- a/src/cyanrip_main.h
+++ b/src/cyanrip_main.h
@@ -30,6 +30,7 @@
 
 #include <cdio/paranoia/paranoia.h>
 #include <cdio/audio.h>
+#include <cdio/mmc_ll_cmds.h>
 #include <libavutil/mem.h>
 #include <libavutil/dict.h>
 #include <libavutil/avstring.h>
@@ -120,6 +121,7 @@ typedef struct cyanrip_settings {
     int disable_coverart_embedding;
     enum coverart_lookup_sizes coverart_lookup_size;
     int enable_replaygain;
+    int data_as_iso;
 
     enum cyanrip_output_formats outputs[CYANRIP_FORMATS_NB];
     int outputs_num;


### PR DESCRIPTION
Hi, thank you so much for all your amazing work on this!

I've got a number of discs that have a data track, usually in a second session as the last track, but in at least one case in a single session as the first track (!). It'd be lovely to have them ripped along with the audio content.

At the moment I get a .bin file, which is a beautiful FLAC with no content, so I took a poke at it and now I get a FLAC with an entire ISO in it! Plus a bunch of other junk... Ripping multiple times with -Z does let me checksum and repeat, which is nice.

I got a bit stuck on libcdio though. Dumping it as a 2352 byte bin (matching the MODE1/2352 you are currently writing to the cue) would be the most traditional archiving method, but libcdio doesn't officially support it! Using the audio read methods sort of works, but I get 36 bytes at the start of each sector that don't belong there... I guess that's what the sync header is for but it also smells a bit like that's going to be drive dependent and messy down the track (if you'll pardon the pun, I promise that wasn't on purpose!)

The other option is to suck it up and do 2048 byte sectors with `cdio_read_mode1_sectors`. This seems to work just fine, no sync issues, most portable, and gives you an .iso directly; an enthusiastic person would even use cdio's libiso9660 to unpack it in situ. But that means either duplicating or hacking up the ripping loop to handle 2048 byte frames, bypassing the codecs (or can we force data tracks to S16 PCM as a passthrough?) and ideally reading (a lot) more than one frame at a time.

What do you think? Is this a feature you would like? How would you like to see it implemented?