### PR TITLE
Handle DRIVER_OP_UNSUPPORTED return from cdio_get_media_changed()

### DIFF
--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -57,14 +57,12 @@ const cyanrip_out_fmt crip_fmt_info[] = {
     [CYANRIP_FORMAT_PCM]      = { "pcm",      "PCM",  "pcm",   "s16le", 0,  0, 1, AV_CODEC_ID_NONE,      },
 };
 
-// TODO Fix cdio_get_media_changed() behavior for macOS upstream in libcdio.
-// Currently it always returns non-zero.
 static int get_media_changed(CdIo_t *cdio) {
-    #ifdef __APPLE__
+    const int rc = cdio_get_media_changed(cdio);
+    if (rc == 0 || rc == DRIVER_OP_UNSUPPORTED)
         return 0;
-    #else
-        return cdio_get_media_changed(cdio);
-    #endif
+    else
+        return 1;;
 }
 
 static void free_track(cyanrip_ctx *ctx, cyanrip_track *t)

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -58,11 +58,8 @@ const cyanrip_out_fmt crip_fmt_info[] = {
 };
 
 static int get_media_changed(CdIo_t *cdio) {
-    const int rc = cdio_get_media_changed(cdio);
-    if (rc == 0 || rc == DRIVER_OP_UNSUPPORTED)
-        return 0;
-    else
-        return 1;
+    const int ret = cdio_get_media_changed(cdio);
+    return ret != 0 && ret != DRIVER_OP_UNSUPPORTED;
 }
 
 static void free_track(cyanrip_ctx *ctx, cyanrip_track *t)

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -62,7 +62,7 @@ static int get_media_changed(CdIo_t *cdio) {
     if (rc == 0 || rc == DRIVER_OP_UNSUPPORTED)
         return 0;
     else
-        return 1;;
+        return 1;
 }
 
 static void free_track(cyanrip_ctx *ctx, cyanrip_track *t)

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -57,6 +57,16 @@ const cyanrip_out_fmt crip_fmt_info[] = {
     [CYANRIP_FORMAT_PCM]      = { "pcm",      "PCM",  "pcm",   "s16le", 0,  0, 1, AV_CODEC_ID_NONE,      },
 };
 
+// TODO Fix cdio_get_media_changed() behavior for macOS upstream in libcdio.
+// Currently it always returns non-zero.
+static int get_media_changed(CdIo_t *cdio) {
+    #ifdef __APPLE__
+        return 0;
+    #else
+        return cdio_get_media_changed(cdio);
+    #endif
+}
+
 static void free_track(cyanrip_ctx *ctx, cyanrip_track *t)
 {
     if (quit_now)
@@ -250,7 +260,7 @@ static int cyanrip_ctx_init(cyanrip_ctx **s, cyanrip_settings *settings)
     }
 
     /* For hot removal detection - init this so we can detect changes */
-    cdio_get_media_changed(ctx->cdio);
+    get_media_changed(ctx->cdio);
 
     *s = ctx;
     return 0;
@@ -609,7 +619,7 @@ repeat_ripping:;
     /* Read the actual CD data */
     for (int i = 0; i < frames; i++) {
         /* Detect disc removals */
-        if (cdio_get_media_changed(ctx->cdio)) {
+        if (get_media_changed(ctx->cdio)) {
             cyanrip_log(ctx, 0, "\nDrive media changed, stopping!\n");
             ret = AVERROR(EINVAL);
             goto fail;
@@ -2099,7 +2109,7 @@ int main(int argc, char **argv)
                 track_read_extra(ctx, t);
                 cyanrip_log_track_end(ctx, t);
 
-                if (cdio_get_media_changed(ctx->cdio)) {
+                if (get_media_changed(ctx->cdio)) {
                     cyanrip_log(ctx, 0, "Drive media changed, stopping!\n");
                     break;
                 }
@@ -2192,7 +2202,7 @@ int main(int argc, char **argv)
                 track_read_extra(ctx, t);
                 cyanrip_log_track_end(ctx, t);
 
-                if (cdio_get_media_changed(ctx->cdio)) {
+                if (get_media_changed(ctx->cdio)) {
                     cyanrip_log(ctx, 0, "Drive media changed, stopping!\n");
                     break;
                 }


### PR DESCRIPTION
Right now cyanrip segfaults on macOS when trying to rip a physical CD:
```
cyanrip -d /dev/rdisk4 -s 6 -N
Checking /dev/rdisk4 for cdrom...

Opening drive...
Release ID unavailable, cannot search Cover Art DB!
Unable to get AccuRIP DB data: missing entry!
cyanrip 0.9.3 (7f74e52)
System device:  /dev/rdisk4
Offset:         +6 samples
Overread:       +1 frame
Overread mode:  fill with silence in lead-in/lead-out
Speed:          default (changeable)
C2 errors:      unsupported by drive
Paranoia level: max
Frame retries:  10
HDCD decoding:  disabled
Album Art:      none
Outputs:        flac
Disc tracks:    13
Tracks to rip:  all
DiscID:         En1ATXvRKHKQhaES95fcMHQegtU-
CDDB ID:        A80AA00D
Album:          Unknown disc (EN1A)
AccurateRip:    not found
Total time:     00:45:20.093

Gaps:
    None signalled

Tracks:

Drive media changed, stopping!
Album Loudness Summary:

  Integrated loudness:
    I:         -70.0 LUFS
    Threshold:   0.0 LUFS

  Loudness range:
    LRA:         0.0 LU
    Threshold:   0.0 LUFS
    LRA low:     0.0 LUFS
    LRA high:    0.0 LUFS

  True peak:
    Peak:        0.0 dBFS

zsh: segmentation fault  ./src/cyanrip -d /dev/rdisk4 -s 6 -N
```

The cause turns out to be `cdio_get_media_changed()`. The libcdio osx driver doesn't implement this function and so `cdio_get_media_changed()` always returns DRIVER_OP_UNSUPPORTED. Currently, cyanrip interprets any non-zero return as a media change. This changes that so that DRIVER_OP_UNSUPPORTED returns are not interpreted as a media change.