### PR TITLE
Fix Windows Build

### DIFF
--- a/.github/mingw-build.sh
+++ b/.github/mingw-build.sh
@@ -64,7 +64,7 @@ cyan_do_separate_confmakeinstall() {
 }
 
 cyan_do_cmakeinstall() {
-    PKG_CONFIG=pkg-config cmake -B _build -G Ninja -DBUILD_SHARED_LIBS=off \
+    PKG_CONFIG=pkg-config cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -B _build -G Ninja -DBUILD_SHARED_LIBS=off \
             -DCMAKE_INSTALL_PREFIX="$CYANRIPINSTALLDIR" -DUNIX=on \
             -DCMAKE_FIND_ROOT_PATH="$(cygpath -pm "$CYANRIPINSTALLDIR:$MINGW_PREFIX:$MINGW_PREFIX/$MINGW_CHOST")" \
             -DCMAKE_PREFIX_PATH="$(cygpath -pm "$CYANRIPINSTALLDIR:$MINGW_PREFIX:$MINGW_PREFIX/$MINGW_CHOST")" \
@@ -80,7 +80,8 @@ build_curl() {
     sed -ri "s;(^SUBDIRS = lib) src (include) scripts;\1 \2;" Makefile.in &&
 #    CPPFLAGS+=" -DNGHTTP2_STATICLIB" \
     cyan_do_separate_confmakeinstall --with-{winssl,winidn,nghttp2} \
-        --without-{ssl,gnutls,mbedtls,libssh2,random,ca-bundle,ca-path,librtmp,brotli,debug,libpsl,zstd,nghttp2,ldap,ldaps,ldap-lib}
+        --without-{ssl,gnutls,mbedtls,libssh2,random,ca-bundle,ca-path,librtmp,brotli,debug,libpsl,zstd,nghttp2,ldap,ldap-lib} \
+        --disable-{ldap,ldaps}
 }
 
 build_neon() {
@@ -98,7 +99,7 @@ build_ffmpeg() {
     cyan_do_vcs "https://git.ffmpeg.org/ffmpeg.git"
     cyan_do_separate_confmakeinstall --pkg-config-flags=--static \
         --disable-{programs,devices,filters,decoders,hwaccels,encoders,muxers} \
-        --disable-{debug,protocols,demuxers,parsers,doc,swscale,postproc,network} \
+        --disable-{debug,protocols,demuxers,parsers,doc,swscale,network} \
         --disable-{avdevice,autodetect} \
         --disable-bsfs --enable-protocol=file,data \
         --enable-encoder=flac,tta,aac,wavpack,alac,pcm_s16le,pcm_s32le \
@@ -117,7 +118,7 @@ build_cyanrip() {
     PKG_CONFIG=pkg-config \
     CFLAGS+=" -DLIBXML_STATIC -DCURL_STATICLIB $(printf ' -I%s' "$(cygpath -m "$CYANRIPINSTALLDIR/include")")" \
         LDFLAGS+="$(printf ' -L%s' "$(cygpath -m "$CYANRIPINSTALLDIR/lib")")" \
-        meson build --default-library=static --buildtype=release --prefix="$CYANRIPINSTALLDIR" --backend=ninja &&
+        meson setup build --default-library=static --buildtype=release --prefix="$CYANRIPINSTALLDIR" --backend=ninja &&
     ninja -C build && strip --strip-all build/src/cyanrip.exe -o cyanrip.exe
 }
 

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -1389,8 +1389,8 @@ char *crip_get_path(cyanrip_ctx *ctx, enum CRIPPathType type, int create_dirs,
 end:
     for (int i = 0; i < dir_list_nb; i++) {
         if (create_dirs) {
-            crip_stat_t st_req = { 0 };
-            if (crip_stat(dir_list[i], &st_req) == -1)
+            cyanrip_stat_t st_req = { 0 };
+            if (cyanrip_stat(dir_list[i], &st_req) == -1)
                 mkdir(dir_list[i], 0700);
         }
         av_free(dir_list[i]);

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -1389,7 +1389,7 @@ char *crip_get_path(cyanrip_ctx *ctx, enum CRIPPathType type, int create_dirs,
 end:
     for (int i = 0; i < dir_list_nb; i++) {
         if (create_dirs) {
-            struct stat st_req = { 0 };
+            crip_stat_t st_req = { 0 };
             if (crip_stat(dir_list[i], &st_req) == -1)
                 mkdir(dir_list[i], 0700);
         }

--- a/src/os_compat.h
+++ b/src/os_compat.h
@@ -28,7 +28,7 @@
 #include <wchar.h>
 #include <libavutil/mem.h>
 
-typedef struct __stat64 crip_stat_t;
+typedef struct __stat64 cyanrip_stat_t;
 
 static inline int utf8towchar(const char *filename_utf8, wchar_t **filename_w)
 {
@@ -39,6 +39,7 @@ static inline int utf8towchar(const char *filename_utf8, wchar_t **filename_w)
     MultiByteToWideChar(CP_UTF8, 0, filename_utf8, -1, *filename_w, num_chars);
     return 0;
 }
+
 static inline int win32_mkdir(const char *filename_utf8)
 {
     wchar_t *filename_w;
@@ -50,7 +51,7 @@ static inline int win32_mkdir(const char *filename_utf8)
     return ret;
 }
 
-static inline int crip_stat(const char *filename_utf8, crip_stat_t* statbuf)
+static inline int cyanrip_stat(const char *filename_utf8, cyanrip_stat_t* statbuf)
 {
     wchar_t *filename_w;
     int ret;
@@ -65,8 +66,8 @@ static inline int crip_stat(const char *filename_utf8, crip_stat_t* statbuf)
 
 #define mkdir(path, mode) win32_mkdir(path)
 #else
-typedef struct stat crip_stat_t;
-#define crip_stat stat
+typedef struct stat cyanrip_stat_t;
+#define cyanrip_stat stat
 #endif
 
 #if defined(__MACH__)

--- a/src/os_compat.h
+++ b/src/os_compat.h
@@ -28,6 +28,8 @@
 #include <wchar.h>
 #include <libavutil/mem.h>
 
+typedef struct __stat64 crip_stat_t;
+
 static inline int utf8towchar(const char *filename_utf8, wchar_t **filename_w)
 {
     int num_chars = MultiByteToWideChar(CP_UTF8, 0, filename_utf8, -1, NULL, 0);
@@ -37,7 +39,6 @@ static inline int utf8towchar(const char *filename_utf8, wchar_t **filename_w)
     MultiByteToWideChar(CP_UTF8, 0, filename_utf8, -1, *filename_w, num_chars);
     return 0;
 }
-
 static inline int win32_mkdir(const char *filename_utf8)
 {
     wchar_t *filename_w;
@@ -49,7 +50,7 @@ static inline int win32_mkdir(const char *filename_utf8)
     return ret;
 }
 
-static inline int crip_stat(const char *filename_utf8, struct stat* statbuf)
+static inline int crip_stat(const char *filename_utf8, crip_stat_t* statbuf)
 {
     wchar_t *filename_w;
     int ret;
@@ -64,6 +65,7 @@ static inline int crip_stat(const char *filename_utf8, struct stat* statbuf)
 
 #define mkdir(path, mode) win32_mkdir(path)
 #else
+typedef struct stat crip_stat_t;
 #define crip_stat stat
 #endif
 


### PR DESCRIPTION
I found that the Github Action for creating the Windows release wasn't working over on my fork. This is a minimal set of changes to get it working again that I thought you might find useful. Apparently there have been updates to curl, cmake, and ffmpeg that broke the build. The build was also unhappy about `struct stat` on Windows. I'm not sure why that would have changed. Maybe an update to mingw?