### PR TITLE
Also report peaks as sample peak relative amplitude

### DIFF
--- a/src/cyanrip_encode.c
+++ b/src/cyanrip_encode.c
@@ -386,7 +386,7 @@ static int init_filtering(cyanrip_ctx *ctx, cyanrip_filt_ctx *s,
 
     const char *filter_desc = hdcd ? "hdcd" :
                               deemphasis ? "aemphasis=type=cd" :
-                              peak ? "ebur128=peak=true+sample+true,anullsink" :
+                              peak ? "ebur128=peak=true+sample,anullsink" :
                               NULL;
 
     ret = avfilter_graph_parse_ptr(s->graph, filter_desc, &inputs, &outputs, NULL);

--- a/src/cyanrip_encode.c
+++ b/src/cyanrip_encode.c
@@ -386,7 +386,7 @@ static int init_filtering(cyanrip_ctx *ctx, cyanrip_filt_ctx *s,
 
     const char *filter_desc = hdcd ? "hdcd" :
                               deemphasis ? "aemphasis=type=cd" :
-                              peak ? "ebur128=peak=true,anullsink" :
+                              peak ? "ebur128=peak=true+sample+true,anullsink" :
                               NULL;
 
     ret = avfilter_graph_parse_ptr(s->graph, filter_desc, &inputs, &outputs, NULL);

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -584,6 +584,22 @@ static void track_read_extra(cyanrip_ctx *ctx, cyanrip_track *t)
     }
 }
 
+static double sample_peak_rel_amp(const uint8_t *data, const int bytes) {
+    const int16_t* samples = (int16_t*)data;
+    const int bytes_per_sample = 2;
+    const int sample_num = bytes / bytes_per_sample;
+
+    /* At least int32 needed to accomodate abs(-INT16_MIN) */
+    int_fast32_t sample_peak = 0;
+    for (int i = 0; i < sample_num; ++i) {
+        const int_fast32_t abs_sample = abs((int_fast32_t)samples[i]);
+        sample_peak = FFMAX(sample_peak, abs_sample);
+    }
+
+    const double sample_peak_max = abs(INT16_MIN);
+    return (double)sample_peak/sample_peak_max;
+}
+
 static int cyanrip_rip_track(cyanrip_ctx *ctx, cyanrip_track *t)
 {
     int ret = 0;
@@ -649,6 +665,7 @@ repeat_ripping:;
     }
 
     int64_t frame_last_read = av_gettime_relative();
+    double track_sample_peak_rel_amp_precise = 0.0;
 
     /* Read the actual CD data */
     for (int i = 0; i < frames; i++) {
@@ -691,6 +708,11 @@ repeat_ripping:;
 
         /* Update checksums */
         crip_process_checksums(&checksum_ctx, data, bytes);
+
+        /* Update sample peak */
+        const double frame_sample_peak_rel_amp_precise = sample_peak_rel_amp(data, bytes);
+        track_sample_peak_rel_amp_precise =
+            FFMAX(frame_sample_peak_rel_amp_precise, track_sample_peak_rel_amp_precise);
 
         /* Decode and encode */
         if (!ctx->settings.ripping_retries || repeat_mode_encode) {
@@ -872,6 +894,14 @@ end:
     t->total_repeats = total_repeats;
     if (!quit_now && !ret) {
         cyanrip_finalize_encoding(ctx, t);
+        const double track_true_peak_rel_amp_ebu = pow(10, t->ebu_true_peak/20);
+        const double track_sample_peak_rel_amp_ebu = pow(10, t->ebu_sample_peak/20);
+        cyanrip_log(ctx, 0, "  Sample peak relative amplitude (calculated from ebur128 dBFS):\n");
+        cyanrip_log(ctx, 0, "    Peak:        %f\n\n", track_sample_peak_rel_amp_ebu); 
+        cyanrip_log(ctx, 0, "  Sample peak relative amplitude (precise):\n");
+        cyanrip_log(ctx, 0, "    Peak:        %f\n\n", track_sample_peak_rel_amp_precise); 
+        cyanrip_log(ctx, 0, "  True peak relative amplitude (calculated from ebur128 dBFS):\n");
+        cyanrip_log(ctx, 0, "    Peak:        %f\n\n", track_true_peak_rel_amp_ebu); 
         if (ctx->settings.enable_replaygain)
             crip_replaygain_meta_track(ctx, t);
         cyanrip_log_track_end(ctx, t);


### PR DESCRIPTION
By "sample peak relative amplitude" what I mean is:
sample peak: value is taken from an actual sample
relative amplitude: as a fraction of the maximum possible value instead of dBFS

Providing this number allows comparison with EAC and XLD logs and this number is commonly used as a basic "fingerprint" to help determine if a disc is a distinct mastering.

This is almost in good shape to be merged although you'll need to tell me how you'd like this reported in the logs. Right now it's very programmer-oriented:

```
  Sample peak:
    Peak:       -0.3 dBFS

  True peak:
    Peak:       -0.3 dBFS

  Sample peak relative amplitude (calculated from ebur128 dBFS):
    Peak:        0.965973

  Sample peak relative amplitude (precise):
    Peak:        0.965973

  True peak relative amplitude (calculated from ebur128 dBFS):
    Peak:        0.970680
```

I started off just calculating from the ebur128 dBFS, but that result is sometimes slightly off compared to XLD, presumably due to rounding error. I then added "precise", which is a simple iteration over all the samples, which as far as I've seen always matches XLD.

I'm not quite sure how best to tidy up the log. The two values that matter here are one of true peaks and `Sample peak relative amplitude (precise)`. Maybe show the values for only `True peak relative amplitude (calculated from ebur128 dBFS)` and `Sample peak relative amplitude (precise)` and clean up their names?

Thoughts?