### PR TITLE
Log "Track X ripped and encoded with errors." when appropriate.

### DIFF
--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -815,8 +815,12 @@ finalize_ripping:
     }
 
 fail:
-    if (!ret && !quit_now)
-        cyanrip_log(ctx, 0, "Track %i ripped and encoded successfully!\n", t->number);
+    if (!ret && !quit_now) {
+        if (ctx->total_error_count - start_err)
+            cyanrip_log(ctx, 0, "Track %i ripped and encoded with errors.\n", t->number);
+        else
+            cyanrip_log(ctx, 0, "Track %i ripped and encoded successfully!\n", t->number);
+    }
 
 end:
     av_free(last_checksums);


### PR DESCRIPTION
cyanrip sometimes writes to the log "Track X ripped and encoded successfully!" even when a rip was unsuccessful. I encountered this when ripping an HTOA disc using a non-HTOA-capable drive:
```
cdio error: 007: Unknown, unrecoverable error reading data
007: Unknown, unrecoverable error reading data
007: Unknown, unrecoverable error reading data

Track 0 ripped and encoded successfully!
```

This pull request changes that message to "Track X ripped and encoded with errors." in cases where a track finishes ripping and encoding but the total error count increased:
```
cdio error: 007: Unknown, unrecoverable error reading data
007: Unknown, unrecoverable error reading data
007: Unknown, unrecoverable error reading data

Track 0 ripped and encoded with errors.
```

Currently, I believe any such errors that occur between when `start_err` is set and checked against `ctx->total_error_count` would have to originate in `cyanrip_read_frame()` due to either errors indicated by cdparanoia itself (https://github.com/libcdio/libcdio-paranoia/blob/master/include/cdio/paranoia/cdda.h#L365) or from cyanrip somehow getting a NULL pointer back from cdparanoia, both of which indicate something severely wrong. The rip is likely bad and that should be made clear in the log.