### PR TITLE
Fix handling of no pregap for merged pregap tracks in cue writer.

### DIFF
--- a/src/cue_writer.c
+++ b/src/cue_writer.c
@@ -81,9 +81,10 @@ void cyanrip_cue_track(cyanrip_ctx *ctx, cyanrip_track *t)
     char time_01[16];
 
     /* Finish over the pregap which has been appended to the last track */
-    const int write_appended_pregap = (t->pregap_lsn != CDIO_INVALID_LSN && t->pt &&
-        t->dropped_pregap_start == CDIO_INVALID_LSN &&
-        t->merged_pregap_end == CDIO_INVALID_LSN);
+    const int write_appended_pregap = (
+        t->pregap_lsn != CDIO_INVALID_LSN && t->pregap_lsn != t->start_lsn && t->pt
+        && t->dropped_pregap_start == CDIO_INVALID_LSN
+        && t->merged_pregap_end == CDIO_INVALID_LSN);
     if (write_appended_pregap) {
         for (int Z = 0; Z < ctx->settings.outputs_num; Z++)
             fprintf(ctx->cuefile[Z], "  TRACK %02d AUDIO\n", t->index);


### PR DESCRIPTION
Small fix to my pull request for the cue writer. It should have been this way in the original pull request but somehow I mixed things up.

`t->pregap_lsn != t->start_lsn` is the correct test for no pregap and needs to be included here.