### PR TITLE
Flush stdout after writing line to buffer

### DIFF
--- a/src/cyanrip_log.c
+++ b/src/cyanrip_log.c
@@ -517,6 +517,7 @@ void cyanrip_log(cyanrip_ctx *ctx, int verbose, const char *format, ...)
     }
 
     vprintf(format, args);
+    fflush(stdout);
 
     va_end(args);
 


### PR DESCRIPTION
Log lines come in spurts already. Since no newline is printed, there's no flushing by the stdlib and the log is especially erratic. Help things along by flushing manually.