### PR TITLE
Flatpak support

### DIFF
--- a/com.github.cyanreg.cyanrip.metainfo.xml
+++ b/com.github.cyanreg.cyanrip.metainfo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>com.github.cyanreg.cyanrip</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.1-or-later</project_license>
+  <name>cyanrip</name>
+  <summary>Fully featured CD ripping program</summary>
+  <description>
+    <p>
+      cyanrip is a fully featured CD ripping program able to take out most of
+      the tedium. Fully accurate, has advanced features most rippers don't,
+      yet has no bloat and is cross-platform.
+    </p>
+    <p>Features include:</p>
+    <ul>
+      <li>Automatic tag lookup from the MusicBrainz database</li>
+      <li>Encoded and muxed via FFmpeg (supports flac, opus, mp3, tta, wavpack, alac, vorbis and aac)</li>
+      <li>Drive offset compensation and error recovery via cd-paranoia</li>
+      <li>Full pregap handling</li>
+      <li>HDCD detection and decoding</li>
+      <li>CD Deemphasis (TOC + subcode)</li>
+      <li>Multi-disc album ripping</li>
+      <li>ReplayGain v2 tagging</li>
+      <li>Able to encode to multiple formats in parallel</li>
+      <li>Cover image embedding in mp3, flac, aac and opus</li>
+      <li>Automatic cover art image downloading</li>
+      <li>Provides and automatically verifies EAC CRC32, AccurateRip V1 and V2 checksums</li>
+      <li>Accurate ripping verification of partially damaged tracks</li>
+      <li>Automatic drive offset finding</li>
+    </ul>
+  </description>
+  <developer id="github.cyanreg">
+    <name>cyanreg</name>
+  </developer>
+  <url type="homepage">https://github.com/cyanreg/cyanrip</url>
+  <url type="bugtracker">https://github.com/cyanreg/cyanrip/issues</url>
+  <provides>
+    <binary>cyanrip</binary>
+  </provides>
+  <releases>
+    <release version="0.9.3.1" date="2024-06-05"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,11 @@ cc = meson.get_compiler('c')
 subdir('src')
 subdir('tests')
 
+install_data(
+    'com.github.cyanreg.cyanrip.metainfo.xml',
+    install_dir: get_option('datadir') / 'metainfo',
+)
+
 configure_file(
     output: 'config.h',
     configuration: conf,


### PR DESCRIPTION
It might be redundant for people using up-to-date or rolling distros but it is very useful for people who are
conservative with updates.

I tried my best to complete the info. The metainfo.xml file does not strictly need to be installed for the flatpak to work,
but it will show the software as installed in gnome-software even when using debs or rpms.

The following manifest can be used for submission to flathub:

```
id: com.github.cyanreg.cyanrip
runtime: org.freedesktop.Platform
runtime-version: '24.08'
sdk: org.freedesktop.Sdk
command: cyanrip
finish-args:
    - --device=all
    - --filesystem=xdg-music
    - --filesystem=home
    - --share=network
modules:
    - name: libcdio
      buildsystem: autotools
      config-opts:
          - --disable-example-progs
          - --without-cd-drive
          - --without-cd-info
          - --without-cdda-player
          - --without-cd-read
          - --without-iso-info
          - --without-iso-read
          - --enable-rock
          - --enable-cddb
      sources:
          - type: archive
            url: https://github.com/libcdio/libcdio/releases/download/2.3.0/libcdio-2.3.0.tar.bz2
            sha256: 53e83d284667535a767fd2d31edad1a6701591960459df373a10f1f21e80a7ed

    - name: libcdio-paranoia
      buildsystem: autotools
      sources:
          - type: archive
            url: https://github.com/libcdio/libcdio-paranoia/releases/download/release-10.2%2B2.0.2/libcdio-paranoia-10.2+2.0.2.tar.bz2
            sha256: 186892539dedd661276014d71318c8c8f97ecb1250a86625256abd4defbf0d0c

    - name: neon
      buildsystem: autotools
      config-opts:
          - --with-ssl=openssl
          - --enable-shared
          - --disable-static
      sources:
          - type: archive
            url: https://notroj.github.io/neon/neon-0.33.0.tar.gz
            sha256: 659a5cc9cea05e6e7864094f1e13a77abbbdbab452f04d751a8c16a9447cf4b8

    - name: libmusicbrainz5
      buildsystem: cmake-ninja
      config-opts:
          - -DCMAKE_CXX_FLAGS=-fpermissive
      sources:
          - type: archive
            url: https://github.com/metabrainz/libmusicbrainz/releases/download/release-5.1.0/libmusicbrainz-5.1.0.tar.gz
            sha256: 6749259e89bbb273f3f5ad7acdffb7c47a2cf8fcaeab4c4695484cef5f4c6b46

    - name: cyanrip
      buildsystem: meson
      sources:
          - type: archive
            url: https://github.com/cyanreg/cyanrip/releases/download/v0.9.3.1/cyanrip-src-v0.9.3.1.tar.gz
            sha256: fa7bc916ff91a17992b1695fa40dcb17eeeb840cd65c0cf26c1f1ddbc11f42eb
```