### PR TITLE
accurip: parse CDDB ID with strtoul to fix AccurateRip on Windows

### DIFF
--- a/src/accurip.c
+++ b/src/accurip.c
@@ -99,7 +99,7 @@ int crip_fill_accurip(cyanrip_ctx *ctx)
     }
 
     /* Format all the data in the needed way */
-    uint32_t cddb_id = strtol(cddb_id_str, NULL, 16);
+    uint32_t cddb_id = strtoul(cddb_id_str, NULL, 16);
     char id_type_1_s[9] = { 0 };
     snprintf(id_type_1_s, sizeof(id_type_1_s), "%08x", id_type_1);
 


### PR DESCRIPTION
## Summary

On Windows, AccurateRip lookups fail with `AccurateRip: not found` for any
disc whose CDDB disc ID has its top bit set (ID ≥ `0x80000000`), even when the
disc is in the AccurateRip database.

The CDDB ID is parsed with `strtol` (`src/accurip.c:102`), whose return type is
a signed `long`. On Windows (LLP64) `long` is 32-bit, so any value above
`LONG_MAX` saturates to `0x7FFFFFFF` (with `errno = ERANGE`). That truncated
value is formatted into the request URL, so the lookup 404s. Linux/macOS
(LP64, 64-bit `long`) fit the value, which is why it only manifests on Windows.

The value is an unsigned 32-bit disc ID, so this parses it with `strtoul`,
whose `unsigned long` return type covers the full range on every platform. The
result already lands in a `uint32_t`, so no other change is needed.

Fixes #145.
