### PR TITLE
Report track peak in logs

### DIFF
--- a/src/cyanrip_log.c
+++ b/src/cyanrip_log.c
@@ -103,6 +103,7 @@ void cyanrip_log_track_end(cyanrip_ctx *ctx, cyanrip_track *t)
     cyanrip_log(ctx, 0, "    Duration:    %s\n", length);
     cyanrip_log(ctx, 0, "    Samples:     %u\n", t->nb_samples);
     cyanrip_log(ctx, 0, "    Frames:      %u\n", t->end_lsn_sig - t->start_lsn_sig + 1);
+    cyanrip_log(ctx, 0, "    Peak:        %.6f\n", t->sample_peak_rel_amp);
 
     print_offsets(ctx, t);
 

--- a/src/cyanrip_log.c
+++ b/src/cyanrip_log.c
@@ -103,7 +103,7 @@ void cyanrip_log_track_end(cyanrip_ctx *ctx, cyanrip_track *t)
     cyanrip_log(ctx, 0, "    Duration:    %s\n", length);
     cyanrip_log(ctx, 0, "    Samples:     %u\n", t->nb_samples);
     cyanrip_log(ctx, 0, "    Frames:      %u\n", t->end_lsn_sig - t->start_lsn_sig + 1);
-    cyanrip_log(ctx, 0, "    Peak:        %.6f\n", t->sample_peak_rel_amp);
+    cyanrip_log(ctx, 0, "    Sample peak: %.6f\n", t->sample_peak_rel_amp);
 
     print_offsets(ctx, t);
 

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -616,10 +616,11 @@ static void track_read_extra(cyanrip_ctx *ctx, cyanrip_track *t)
 
 /**
  * Largest absolute sample value divided by 32768.0 (the largest absolute value of a signed 16-bit sample).
- * This is used to calculate the true peak amplitude of the audio samples in a track,
+ * This is used to calculate the sample peak relative amplitude of the audio samples in a track,
  * which is important for identifying the track.
  */
-static double sample_peak_rel_amp(const uint8_t *data, const int bytes) {
+static double sample_peak_rel_amp(const uint8_t *data, const int bytes)
+{
     const int16_t* samples = (int16_t*)data;
     const int bytes_per_sample = 2;
     const int sample_num = bytes / bytes_per_sample;
@@ -680,6 +681,10 @@ repeat_ripping:;
     /* Checksum */
     cyanrip_checksum_ctx checksum_ctx;
     crip_init_checksum_ctx(ctx, &checksum_ctx, t);
+
+    /* Reset sample peak for this attempt - a bad sample from a discarded
+     * (non-matching) repeat ripping pass must not stick around forever. */
+    t->sample_peak_rel_amp = 0.0;
 
     /* Fill with silence to maintain track length */
     for (int i = 0; i < frames_before_disc_start; i++) {

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -614,29 +614,15 @@ static void track_read_extra(cyanrip_ctx *ctx, cyanrip_track *t)
     }
 }
 
-/**
- * Largest absolute sample value divided by 32768.0 (the largest absolute value of a signed 16-bit sample).
- * This is used to calculate the sample peak relative amplitude of the audio samples in a track,
- * which is important for identifying the track.
- */
 static double sample_peak_rel_amp(const uint8_t *data, const int bytes)
 {
     const int16_t* samples = (int16_t*)data;
-    const int bytes_per_sample = 2;
-    const int sample_num = bytes / bytes_per_sample;
+    const int sample_num = bytes / 2;
 
     /* At least 32 bits needed to accomodate abs(INT16_MIN) */
     int32_t sample_peak = 0;
     for (int i = 0; i < sample_num; ++i) {
-        /* int is usually 32-bit but technically it can be 16-bit. Make sure
-         * we're using a wide enough abs() just in case someone runs this on a
-         * toaster.
-         */
-        #if (INT_MAX >= 32768)
-            sample_peak = FFMAX(sample_peak, abs(samples[i]));
-        #else
-            sample_peak = FFMAX(sample_peak, labs(samples[i]));
-        #endif
+        sample_peak = FFMAX(sample_peak, abs(samples[i]));
     }
 
     /* The greatest sample absolute value is abs(INT16_MIN) = 32768 */

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -619,8 +619,7 @@ static double sample_peak_rel_amp(const uint8_t *data, const int bytes)
     const int16_t* samples = (int16_t*)data;
     const int sample_num = bytes / 2;
 
-    /* At least 32 bits needed to accomodate abs(INT16_MIN) */
-    int32_t sample_peak = 0;
+    int sample_peak = 0;
     for (int i = 0; i < sample_num; ++i) {
         sample_peak = FFMAX(sample_peak, abs(samples[i]));
     }

--- a/src/cyanrip_main.c
+++ b/src/cyanrip_main.c
@@ -614,6 +614,34 @@ static void track_read_extra(cyanrip_ctx *ctx, cyanrip_track *t)
     }
 }
 
+/**
+ * Largest absolute sample value divided by 32768.0 (the largest absolute value of a signed 16-bit sample).
+ * This is used to calculate the true peak amplitude of the audio samples in a track,
+ * which is important for identifying the track.
+ */
+static double sample_peak_rel_amp(const uint8_t *data, const int bytes) {
+    const int16_t* samples = (int16_t*)data;
+    const int bytes_per_sample = 2;
+    const int sample_num = bytes / bytes_per_sample;
+
+    /* At least 32 bits needed to accomodate abs(INT16_MIN) */
+    int32_t sample_peak = 0;
+    for (int i = 0; i < sample_num; ++i) {
+        /* int is usually 32-bit but technically it can be 16-bit. Make sure
+         * we're using a wide enough abs() just in case someone runs this on a
+         * toaster.
+         */
+        #if (INT_MAX >= 32768)
+            sample_peak = FFMAX(sample_peak, abs(samples[i]));
+        #else
+            sample_peak = FFMAX(sample_peak, labs(samples[i]));
+        #endif
+    }
+
+    /* The greatest sample absolute value is abs(INT16_MIN) = 32768 */
+    return (double)sample_peak/32768.0;
+}
+
 static int cyanrip_rip_track(cyanrip_ctx *ctx, cyanrip_track *t)
 {
     int ret = 0;
@@ -718,6 +746,9 @@ repeat_ripping:;
 
         /* Update checksums */
         crip_process_checksums(&checksum_ctx, data, bytes);
+
+         /* Update sample peak */
+        t->sample_peak_rel_amp = FFMAX(sample_peak_rel_amp(data, bytes), t->sample_peak_rel_amp);
 
         /* Decode and encode */
         if (!ctx->settings.ripping_retries || repeat_mode_encode) {

--- a/src/cyanrip_main.h
+++ b/src/cyanrip_main.h
@@ -196,7 +196,7 @@ typedef struct cyanrip_track {
     double ebu_lra_high;
     double ebu_sample_peak;
     double ebu_true_peak;
-    double sample_peak_rel_amp; /* Relative amplitude of the greatest sample absolute value, (0.0-1.0) */
+    double sample_peak_rel_amp; /* Relative amplitude of the largest sample absolute value, (0.0-1.0) */
 
     struct cyanrip_track *pt;
     struct cyanrip_track *nt;

--- a/src/cyanrip_main.h
+++ b/src/cyanrip_main.h
@@ -196,6 +196,7 @@ typedef struct cyanrip_track {
     double ebu_lra_high;
     double ebu_sample_peak;
     double ebu_true_peak;
+    double sample_peak_rel_amp; // Relative amplitude of the greatest sample absolute value, (0.0-1.0)
 
     struct cyanrip_track *pt;
     struct cyanrip_track *nt;

--- a/src/cyanrip_main.h
+++ b/src/cyanrip_main.h
@@ -196,7 +196,7 @@ typedef struct cyanrip_track {
     double ebu_lra_high;
     double ebu_sample_peak;
     double ebu_true_peak;
-    double sample_peak_rel_amp; // Relative amplitude of the greatest sample absolute value, (0.0-1.0)
+    double sample_peak_rel_amp; /* Relative amplitude of the greatest sample absolute value, (0.0-1.0) */
 
     struct cyanrip_track *pt;
     struct cyanrip_track *nt;


### PR DESCRIPTION
Simpler alternative to: https://github.com/cyanreg/cyanrip/pull/116

The sample_peak_rel_amp was taken from @UltraFuzzy's branch