### PR TITLE
Also test macos build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,26 @@ jobs:
 
       - name: Test
         run: meson test -C build --print-errorlogs
+  
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install meson ninja pkg-config nasm ffmpeg libcdio-paranoia libmusicbrainz curl
+
+      - name: Build
+        run: |
+          export PKG_CONFIG_PATH="$(brew --prefix curl)/lib/pkgconfig:$PKG_CONFIG_PATH"
+          meson setup build
+          ninja -C build
+
+      - name: Test
+        run: |
+          export PKG_CONFIG_PATH="$(brew --prefix curl)/lib/pkgconfig:$PKG_CONFIG_PATH"
+          meson test -C build --print-errorlogs
 
   mingw:
     runs-on: windows-latest

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,6 +5,7 @@ unit_test_deps = [
     dependency('libavutil'),
     dependency('libavcodec'),
     dependency('libcdio'),
+    dependency('libcdio_paranoia'),
 ]
 
 fun512_test = executable('fun512_test',


### PR DESCRIPTION
Added macOS tests to the CI.

The fix in tests/meson.build is required for macOS and it's technically correct since we use libcdio_paranoia.
