### PR TITLE
Prefer track title over recording title

### DIFF
--- a/src/musicbrainz.c
+++ b/src/musicbrainz.c
@@ -166,12 +166,16 @@ static int mb_tracks(cyanrip_ctx *ctx, Mb5Release release, const char *discid, i
 
         READ_MB(mb5_recording_get_id, recording, ctx->tracks[i].meta, "mbid", 0);
 
+        /* Prefer the track title over the recording title */
+        READ_MB(mb5_track_get_title, track, ctx->tracks[i].meta, "title", 0);
+
         Mb5ArtistCredit credit;
+
         if (recording) {
-            READ_MB(mb5_recording_get_title, recording, ctx->tracks[i].meta, "title", 0);
+            if (!dict_get(ctx->tracks[i].meta, "title"))
+                READ_MB(mb5_recording_get_title, recording, ctx->tracks[i].meta, "title", 0);
             credit = mb5_recording_get_artistcredit(recording);
         } else {
-            READ_MB(mb5_track_get_title, track, ctx->tracks[i].meta, "title", 0);
             credit = mb5_track_get_artistcredit(track);
         }
         if (credit)


### PR DESCRIPTION
Use the track title instead of the recording title. The track title is what's on the CD whereas the recording title is used to disambiguate the recording in case the same song is recorded multiple times (eg live A vs live B vs studio)

Fixes: 
- https://github.com/cyanreg/cyanrip/issues/56
- https://github.com/cyanreg/cyanrip/issues/156